### PR TITLE
Fix logging formatter setup for enhanced pipeline

### DIFF
--- a/notebooks/advanced/pipeline_config_enhanced.yaml
+++ b/notebooks/advanced/pipeline_config_enhanced.yaml
@@ -76,7 +76,7 @@ summary:
 logging:
   level: "INFO"  # DEBUG, INFO, WARNING, ERROR
   file: "pipeline_outputs/enhanced_pipeline.log"
-  console: true
+  console: false
   
 # Notification configuration (optional)
 notifications:

--- a/notebooks/advanced/run_enhanced_pipeline.py
+++ b/notebooks/advanced/run_enhanced_pipeline.py
@@ -60,22 +60,30 @@ class EnhancedF1Pipeline:
         self.logger = logging.getLogger('EnhancedF1Pipeline')
         self.logger.setLevel(log_level)
         
+        formatter = logging.Formatter(
+            log_config.get('format', '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        )
+
         # Console handler
         if log_config.get('console', True):
             console_handler = logging.StreamHandler()
             console_handler.setLevel(log_level)
-            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             console_handler.setFormatter(formatter)
             self.logger.addHandler(console_handler)
-        
+
         # File handler
         if log_config.get('file'):
             log_file = Path(log_config['file'])
             log_file.parent.mkdir(exist_ok=True)
             file_handler = logging.FileHandler(log_file)
             file_handler.setLevel(log_level)
-            file_handler.setFormatter(formatter)
+            if formatter:
+                file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)
+
+        if not self.logger.handlers:
+            # Ensure the logger has at least a null handler so logging calls are safe
+            self.logger.addHandler(logging.NullHandler())
     
     def load_shared_data(self):
         """Load F1DB data once for sharing across all components"""


### PR DESCRIPTION
## Summary
- create the enhanced pipeline logging formatter before configuring console or file handlers and reuse it
- add a null handler fallback when both logging handlers are disabled
- disable console logging in the enhanced pipeline config so file-only logging works without formatter errors

## Testing
- python - <<'PY'
from notebooks.advanced.run_enhanced_pipeline import EnhancedF1Pipeline
pipeline = EnhancedF1Pipeline('notebooks/advanced/pipeline_config_enhanced.yaml')
pipeline.logger.info('Test log entry for verification')
PY
- python notebooks/advanced/run_enhanced_pipeline.py --help


------
https://chatgpt.com/codex/tasks/task_e_68ef1f16d064832cbeb7d4891de86fe8